### PR TITLE
adds permission checks on custom WP REST endpoints

### DIFF
--- a/frontend/src/Settings.js
+++ b/frontend/src/Settings.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState }  from 'react';
 import { getSuite } from './api';
 
-const Settings = () => {
+const Settings = ({ nonce, urls }) => {
   const [apiKey, setApiKey] = useState('')
   const [suiteId, setSuiteId] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
@@ -18,17 +18,20 @@ const Settings = () => {
     } catch (error) {
       setErrorMessage(error.message)
     }
-    await fetch(window.gi_ajax.urls.settings, {
+    await fetch(urls.settings, {
       body: JSON.stringify({ apiKey, suiteId }),
       method: 'POST',
       headers: new Headers({
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-WP-Nonce': nonce
       }),
     })
     setSaving(false)
   }
   const getSettings = async () => {
-    const response = await fetch(window.gi_ajax.urls.settings)
+    const response = await fetch(urls.settings, {
+      headers: new Headers({ 'X-WP-Nonce': nonce })
+    })
     const json = await response.json()
     setApiKey(json.value.apiKey)
     setSuiteId(json.value.suiteId)

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,11 +3,12 @@ import ReactDOM from 'react-dom';
 import Dashboard from './Dashboard';
 import Settings from './Settings';
 
+const { suiteId, urls, executeEnabled, nonce } = window.gi_ajax;
 const dashboardContainer = document.getElementById('ghost_inspector_dashboard');
 const settingsContainer = document.getElementById('ghost_inspector_settings');
 if (dashboardContainer) {
-  ReactDOM.render(<Dashboard suiteId={window.gi_ajax.suiteId} executeEnabled={window.gi_ajax.executeEnabled} />, dashboardContainer);
+  ReactDOM.render(<Dashboard suiteId={suiteId} executeEnabled={executeEnabled} />, dashboardContainer);
 }
 if (settingsContainer) {
-  ReactDOM.render(<Settings suiteId={window.gi_ajax.suiteId} />, settingsContainer);
+  ReactDOM.render(<Settings nonce={nonce} urls={urls} />, settingsContainer);
 }


### PR DESCRIPTION
This change uses WP authentication to validate that a user has permissions to access the custom endpoints that were added. It prevents non-admins from getting or modifying the plugin settings (API key and suite ID). I left the proxy endpoint open, since we have our own authentication checks and eventually it will need to be open anyway, if we're going to put the widget on a public WP page.