### PR TITLE
settings UI polish

### DIFF
--- a/frontend/src/Settings.js
+++ b/frontend/src/Settings.js
@@ -58,6 +58,8 @@ const Settings = ({ nonce, urls }) => {
   }
   return (
     <div>
+      <h1>Ghost Inspector Settings</h1>
+      <h2>Automated Website Testing Made Easy</h2>
       {!apiKey && <p><a href="https://app.ghostinspector.com/account" target="_blank" rel="noopener noreferrer" className="button button-primary">Login or sign up to get your API key</a></p>}
       <form onSubmit={updateSettings}>
         <p><label>API Key: <input type="text" value={apiKey} onChange={updateApiKey} /></label></p>

--- a/frontend/src/Settings.js
+++ b/frontend/src/Settings.js
@@ -6,6 +6,7 @@ const Settings = ({ nonce, urls }) => {
   const [suiteId, setSuiteId] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
   const [isSaving, setSaving] = useState(false)
+  const [isGetting, setGetting] = useState(true)
   const updateApiKey = (event) => setApiKey(event.target.value)
   const updateSuiteId = (event) => setSuiteId(event.target.value)
   const updateSettings = async (event) => {
@@ -29,23 +30,42 @@ const Settings = ({ nonce, urls }) => {
     setSaving(false)
   }
   const getSettings = async () => {
+    let json = null
+    let elapsed = false
+    setGetting(true)
+    // display loading for a minimum amount of time to prevent flashing
+    setTimeout(() => {
+      elapsed = true
+      if (json) {
+        setGetting(false)
+      }
+    }, 300)
     const response = await fetch(urls.settings, {
       headers: new Headers({ 'X-WP-Nonce': nonce })
     })
-    const json = await response.json()
+    json = await response.json()
     setApiKey(json.value.apiKey)
     setSuiteId(json.value.suiteId)
+    if (elapsed) {
+      setGetting(false)
+    }
   }
   useEffect(() => {
     getSettings()
   }, [])
+  if (isGetting) {
+    return <p>Loading...</p>
+  }
   return (
-    <form onSubmit={updateSettings}>
-      <p><label>API Key: <input type="text" value={apiKey} onChange={updateApiKey} /></label></p>
-      <p><label>Suite ID: <input type="text" value={suiteId} onChange={updateSuiteId} /></label></p>
-      {errorMessage && <div className="error settings-error"><p>{errorMessage}</p></div>}
-      <p><button type="submit" className="button button-primary" disabled={isSaving}>Submit</button></p>
-    </form>
+    <div>
+      {!apiKey && <p><a href="https://app.ghostinspector.com/account" target="_blank" rel="noopener noreferrer" className="button button-primary">Login or sign up to get your API key</a></p>}
+      <form onSubmit={updateSettings}>
+        <p><label>API Key: <input type="text" value={apiKey} onChange={updateApiKey} /></label></p>
+        <p><label>Suite ID: <input type="text" value={suiteId} onChange={updateSuiteId} /></label></p>
+        {errorMessage && <div className="error settings-error"><p>{errorMessage}</p></div>}
+        <p><button type="submit" className="button button-primary" disabled={isSaving}>Submit</button></p>
+      </form>
+    </div>
   );
 }
 


### PR DESCRIPTION
- adds link to account on settings page when API key is missing
- adds header/subheader to settings page
- adds loading message while fetching settings from Wordpress, with minimum load time so there's no weird flash of content change

https://app.clubhouse.io/ghostinspector/story/1444/prepare-for-submission-to-wordpress-org-plugin-directory