### PR TITLE
table styling and export path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If you want to run this locally, I've included a Docker stack config for Wordpre
 ```
 docker stack deploy -c stack.yml wordpress
 ```
-It will help speed up development to either mount the Docker Wordpress container so you can directly modify the files, or use this command/path to copy the files after saving (adjust for your local):
+It will help speed up development to either mount the Docker Wordpress container so you can directly modify the files, or use this command/path to copy the files after saving (adjust for your local path, container ID):
 ```
 docker cp [local-repo-location]/ghost-inspector.php [your-wordpress-container-id]:/var/www/html/wp-content/plugins/ghost-inspector/ghost-inspector.php
 ```

--- a/frontend/scripts/export.js
+++ b/frontend/scripts/export.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const archiver = require('archiver');
 const path = require('path');
 
+const prefix = 'ghost-inspector'; // folder name
 const output = fs.createWriteStream(path.resolve(__dirname, '../../ghost-inspector.zip'));
 const archive = archiver('zip', { zlib: { level: 9 } }); // Sets the compression level.
 
@@ -37,9 +38,9 @@ archive.on('error', function(err) {
 // pipe archive data to the file
 archive.pipe(output);
 
-archive.glob('../frontend/build/static/js/main.*.js', null, { name: 'ghost-inspector.js' });
-archive.glob('../frontend/build/static/css/main.*.css', null, { name: 'ghost-inspector.css' });
-archive.file(path.resolve(__dirname, '../../ghost-inspector.php'), { name: 'ghost-inspector.php' });
+archive.glob('../frontend/build/static/js/main.*.js', null, { name: 'ghost-inspector.js', prefix });
+archive.glob('../frontend/build/static/css/main.*.css', null, { name: 'ghost-inspector.css', prefix });
+archive.file(path.resolve(__dirname, '../../ghost-inspector.php'), { name: 'ghost-inspector.php', prefix });
 
 // finalize the archive (ie we are done appending files but streams have to finish yet)
 // 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -55,21 +55,26 @@ const Dashboard = ({ suiteId, executeEnabled }) => {
   return (
     <div className="ghost_inspector_wrapper">
       <p className="ghost_inspector_header">Latest results for suite: <a href={`${baseUrl}/suites/${suiteId}`} target="_blank" rel="noopener noreferrer" className="ghost_inspector_suite_name">{suite.name}</a> ({totalPassing}/{total} passing)</p>
-      <ul className="ghost_inspector_tests">
-        {tests.map(test => (
-          <li key={test._id}>
-            <span>
-              <a href={`${baseUrl}/tests/${test._id}`} target="_blank" rel="noopener noreferrer">{test.name}</a>
-            </span>
-            <span className="ghost_inspector_status">
-              <span className={`dashicons dashicons-${test.passing ? 'yes' : 'no'}`}></span>
-            </span>
-            <span>
-              {format(new Date(test.dateExecutionFinished), 'MMM D')}
-            </span>
-          </li>
-        ))}
-      </ul>
+      <div className="ghost_inspector_tests">
+        <table>
+          <tr>
+            <th>Test Name</th>
+            <th>Last Run</th>
+          </tr>
+          {tests.map(test => (
+            <tr key={test._id}>
+              <td>
+                <a href={`${baseUrl}/tests/${test._id}`} target="_blank" rel="noopener noreferrer">{test.name}</a>
+              </td>
+              <td className="ghost_inspector_status">
+                <span className={`dashicons dashicons-${test.passing ? 'yes' : 'no'}`}></span>
+                {format(new Date(test.dateExecutionFinished), 'MMM D')}
+              </td>
+            </tr>
+          ))}
+        </table>
+      </div>
+
       {executeEnabled && <p><button type="button" className="button button-primary" onClick={triggerExecuteSuite} disabled={isSuiteRunning}>Run Test Suite</button></p>}
     </div>
   );

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -58,7 +58,15 @@ const Dashboard = ({ suiteId, executeEnabled }) => {
       <ul className="ghost_inspector_tests">
         {tests.map(test => (
           <li key={test._id}>
-            <a href={`${baseUrl}/tests/${test._id}`} target="_blank" rel="noopener noreferrer">{test.name}</a> <span className={`ghost_inspector_${test.passing ? 'passing' : 'failing'}`}>{test.passing ? 'passed' : 'failed'}</span> on {format(new Date(test.dateExecutionFinished), 'MMM D, YYYY @ h:mm:ss A')}
+            <span>
+              <a href={`${baseUrl}/tests/${test._id}`} target="_blank" rel="noopener noreferrer">{test.name}</a>
+            </span>
+            <span className="ghost_inspector_status">
+              <span className={`dashicons dashicons-${test.passing ? 'yes' : 'no'}`}></span>
+            </span>
+            <span>
+              {format(new Date(test.dateExecutionFinished), 'MMM D')}
+            </span>
           </li>
         ))}
       </ul>

--- a/frontend/src/dashboard.css
+++ b/frontend/src/dashboard.css
@@ -4,11 +4,11 @@
   border-bottom: 1px dotted #8aa7c0;
 }
 
-.ghost_inspector_passing {
+.ghost_inspector_wrapper .dashicons-yes {
   color: #62bf67
 }
 
-.ghost_inspector_failing {
+.ghost_inspector_wrapper .dashicons-no {
   color: #de6764;
 }
 
@@ -21,8 +21,21 @@
   border-top: 1px solid #ddd;
   padding: 6px 11px;
   margin: 0;
+  display: flex;
 }
 
 .ghost_inspector_tests li:nth-of-type(odd) {
   background-color: #f9f9f9;
+}
+
+.ghost_inspector_tests li > span:first-child {
+  flex-grow: 1;
+}
+
+.ghost_inspector_tests .ghost_inspector_status {
+  text-align: center;
+}
+
+.ghost_inspector_tests li > span:last-child {
+  padding-left: 10px;
 }

--- a/frontend/src/dashboard.css
+++ b/frontend/src/dashboard.css
@@ -13,29 +13,40 @@
 }
 
 .postbox .inside .ghost_inspector_tests {
-  margin-left: -11px;
-  margin-right: -11px;
+  margin-left: -12px;
+  margin-right: -12px;
 }
 
-.ghost_inspector_tests li {
+.ghost_inspector_tests table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.ghost_inspector_tests th {
+  font-weight: normal;
+  text-align: left;
+  background-color: #ddd;
+  color: #777;
+}
+
+.ghost_inspector_tests th:last-child {
+  text-align: right;
+}
+
+.ghost_inspector_tests td,
+.ghost_inspector_tests th {
   border-top: 1px solid #ddd;
   padding: 6px 11px;
-  margin: 0;
-  display: flex;
 }
 
-.ghost_inspector_tests li:nth-of-type(odd) {
+.ghost_inspector_tests tr:nth-of-type(odd) td {
   background-color: #f9f9f9;
 }
 
-.ghost_inspector_tests li > span:first-child {
-  flex-grow: 1;
+/* trick to get cell to take up available width */
+.ghost_inspector_tests td {
+  white-space: nowrap;
 }
-
-.ghost_inspector_tests .ghost_inspector_status {
-  text-align: center;
-}
-
-.ghost_inspector_tests li > span:last-child {
-  padding-left: 10px;
+.ghost_inspector_tests td:first-child {
+  width: 99%; /* trick to get cell to take up available width */
 }


### PR DESCRIPTION
- puts test results display on dashboard into a table with headers and more concise styling
- export script puts plugin files into a folder

https://app.clubhouse.io/ghostinspector/story/1459/wordpress-plugin-tweaks