### PR TITLE
prefixes all php global functions/variables

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,6 +1,6 @@
 
 export const request = async (endpoint, params = {}) => {
-  const { urls } = window.gi_ajax
+  const { urls } = window.ghost_inspector_ajax
   const connector = urls.proxy.indexOf('?') > -1 ? '&' : '?' // check for query param in existing WP URL (depends on permalink settings)
   const response = await fetch(`${urls.proxy}${connector}${new URLSearchParams(Object.entries({
     ...params,

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import Dashboard from './Dashboard';
 import Settings from './Settings';
 
-const { suiteId, urls, executeEnabled, nonce } = window.gi_ajax;
+const { suiteId, urls, executeEnabled, nonce } = window.ghost_inspector_ajax;
 const dashboardContainer = document.getElementById('ghost_inspector_dashboard');
 const settingsContainer = document.getElementById('ghost_inspector_settings');
 if (dashboardContainer) {

--- a/ghost-inspector.php
+++ b/ghost-inspector.php
@@ -13,20 +13,20 @@
 */
 
 // proxy requests to the GI API so that the API key remains hidden
-function gi_api_proxy($request) {
-  $gi_params = $request->get_query_params();
-  $gi_params['apiKey'] = get_option('gi_api_key');
-  $gi_endpoint = $gi_params['endpoint'];
-  unset($gi_params['endpoint']);
-  $query = http_build_query($gi_params);
-  $gi_request = wp_remote_get("https://api.ghostinspector.com/v1$gi_endpoint?$query");
-  return json_decode(wp_remote_retrieve_body($gi_request));
+function ghost_inspector_api_proxy($request) {
+  $params = $request->get_query_params();
+  $params['apiKey'] = get_option('ghost_inspector_api_key');
+  $endpoint = $params['endpoint'];
+  unset($params['endpoint']);
+  $query = http_build_query($params);
+  $request = wp_remote_get("https://api.ghostinspector.com/v1$endpoint?$query");
+  return json_decode(wp_remote_retrieve_body($request));
 }
 
 // get saved settings from WP DB
-function gi_get_settings($request) {
-  $api_key = get_option('gi_api_key');
-  $suite_id = get_option('gi_suite_id');
+function ghost_inspector_get_settings($request) {
+  $api_key = get_option('ghost_inspector_api_key');
+  $suite_id = get_option('ghost_inspector_suite_id');
   return new WP_REST_RESPONSE(array(
     'success' => true,
     'value'   => array(
@@ -37,19 +37,19 @@ function gi_get_settings($request) {
 }
 
 // save settings to WP DB
-function gi_update_settings($request) {
-  $gi_json = $request->get_json_params();
+function ghost_inspector_update_settings($request) {
+  $json = $request->get_json_params();
   // store the values in wp_options table
-  $updated_api_key = update_option('gi_api_key', $gi_json['apiKey']);
-  $updated_suite_id = update_option('gi_suite_id', $gi_json['suiteId']);
+  $updated_api_key = update_option('ghost_inspector_api_key', $json['apiKey']);
+  $updated_suite_id = update_option('ghost_inspector_suite_id', $json['suiteId']);
   return new WP_REST_RESPONSE(array(
     'success' => $updated_api_key && $updated_suite_id,
-    'value'   => $gi_json
+    'value'   => $json
   ), 200);
 }
 
 // check permissions
-function gi_settings_permissions_check() {
+function ghost_inspector_settings_permissions_check() {
   // Restrict endpoint to only users who have the capability to manage options.
   if (current_user_can('manage_options')) {
     return true;
@@ -63,51 +63,51 @@ add_action('rest_api_init', function () {
     // By using this constant we ensure that when the WP_REST_Server changes our readable endpoints will work as intended.
     'methods'  => WP_REST_Server::READABLE,
     // Here we register our callback. The callback is fired when this endpoint is matched by the WP_REST_Server class.
-    'callback' => 'gi_api_proxy',
+    'callback' => 'ghost_inspector_api_proxy',
   ));
   register_rest_route('ghost-inspector/v1', '/settings', array(
     'methods'  => WP_REST_Server::READABLE,
-    'callback' => 'gi_get_settings',
-    'permission_callback' => 'gi_settings_permissions_check'
+    'callback' => 'ghost_inspector_get_settings',
+    'permission_callback' => 'ghost_inspector_settings_permissions_check'
   ));
   register_rest_route('ghost-inspector/v1', '/settings', array(
     'methods'  => WP_REST_Server::CREATABLE,
-    'callback' => 'gi_update_settings',
-    'permission_callback' => 'gi_settings_permissions_check'
+    'callback' => 'ghost_inspector_update_settings',
+    'permission_callback' => 'ghost_inspector_settings_permissions_check'
   ));
 });
 
 add_action('admin_enqueue_scripts', function ($hook) {
   // only load scripts on dashboard and settings page
-  global $gi_settings_page;
-  if ($hook != 'index.php' && $hook != $gi_settings_page) {
+  global $ghost_inspector_settings_page;
+  if ($hook != 'index.php' && $hook != $ghost_inspector_settings_page) {
     return;
   }
 
   if (in_array($_SERVER['REMOTE_ADDR'], array('10.255.0.2', '::1'))) {
     // DEV React dynamic loading
-    $gi_js_to_load = 'http://localhost:3000/static/js/bundle.js';
+    $js_to_load = 'http://localhost:3000/static/js/bundle.js';
   } else {
-    $gi_js_to_load = plugin_dir_url( __FILE__ ) . 'ghost-inspector.js';
-    $gi_css_to_load = plugin_dir_url( __FILE__ ) . 'ghost-inspector.css';
+    $js_to_load = plugin_dir_url( __FILE__ ) . 'ghost-inspector.js';
+    $css_to_load = plugin_dir_url( __FILE__ ) . 'ghost-inspector.css';
   }
 
-  wp_enqueue_style('ghost_inspector_styles', $gi_css_to_load);
-  wp_enqueue_script('ghost_inspector_react', $gi_js_to_load, '', mt_rand(10,1000), true);
-  wp_localize_script('ghost_inspector_react', 'gi_ajax', array(
+  wp_enqueue_style('ghost_inspector_styles', $css_to_load);
+  wp_enqueue_script('ghost_inspector_react', $js_to_load, '', mt_rand(10,1000), true);
+  wp_localize_script('ghost_inspector_react', 'ghost_inspector_ajax', array(
     'urls'    => array(
       'proxy'    => rest_url('ghost-inspector/v1/proxy'),
       'settings' => rest_url('ghost-inspector/v1/settings')
     ),
     'nonce'   => wp_create_nonce('wp_rest'),
-    'suiteId' => get_option('gi_suite_id'),
+    'suiteId' => get_option('ghost_inspector_suite_id'),
   ));
 });
 
 // display dashboard widget
 add_action('wp_dashboard_setup', function () {
-  wp_add_dashboard_widget('ghost_inspector_widget', 'Ghost Inspector', 'gi_display_widget');
-  function gi_display_widget() {
+  wp_add_dashboard_widget('ghost_inspector_widget', 'Ghost Inspector', 'ghost_inspector_display_widget');
+  function ghost_inspector_display_widget() {
     ?>
     <div id="ghost_inspector_dashboard"></div>
     <?php
@@ -116,8 +116,8 @@ add_action('wp_dashboard_setup', function () {
 
 // add to settings menu
 add_action('admin_menu', function () {
-  global $gi_settings_page;
-  $gi_settings_page = add_options_page('Ghost Inspector Settings', 'Ghost Inspector', 'manage_options', 'ghost-inspector-settings', 'ghost_inspector_settings_do_page');
+  global $ghost_inspector_settings_page;
+  $ghost_inspector_settings_page = add_options_page('Ghost Inspector Settings', 'Ghost Inspector', 'manage_options', 'ghost-inspector-settings', 'ghost_inspector_settings_do_page');
   // Draw the menu page itself
   function ghost_inspector_settings_do_page() {
     ?>
@@ -135,8 +135,8 @@ add_action('admin_menu', function () {
 
 // cleanup data on uninstall
 function ghost_inspector_uninstall () {
-  delete_option('gi_api_key');
-  delete_option('gi_suite_id');
+  delete_option('ghost_inspector_api_key');
+  delete_option('ghost_inspector_suite_id');
 }
 
 register_uninstall_hook(__FILE__, 'ghost_inspector_uninstall');


### PR DESCRIPTION
switched from just `gi_` in some instances to `ghost_inspector_` everywhere; removed the prefix from any function scoped variables to avoid confusion (hopefully)